### PR TITLE
Add support for GCC 7.5.0.

### DIFF
--- a/include/NifFile.hpp
+++ b/include/NifFile.hpp
@@ -10,7 +10,18 @@ See the included GPLv3 LICENSE file
 #include "Geometry.hpp"
 #include "Nodes.hpp"
 
+#if __has_include(<filesystem>)
+
 #include <filesystem>
+
+#elif __has_include(<experimental/optional>)
+
+#include <experimental/filesystem>
+namespace std::filesystem {
+	using namespace std::experimental::filesystem;
+}
+
+#endif
 
 namespace nifly {
 // OptimizeFor function options

--- a/include/Object3d.hpp
+++ b/include/Object3d.hpp
@@ -6,6 +6,7 @@ See the included GPLv3 LICENSE file
 
 #pragma once
 
+#include <cstdint>
 #include <algorithm>
 #include <cmath>
 #include <cstring>


### PR DESCRIPTION
Hi guys,

I'm on GNU / Linux and GCC 7.5.0 and had to add this two headers to compile, supposedely due to incomplete c++17 implementation.

Very cool and handy project btw, I might switch to it rather than niflib for my own :)

Cheers.