### PR TITLE
Added MatTransform functions; added constexpr to Object3d.hpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.10..3.20)
 
 project(nifly)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 set(NIFLY_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(NIFLY_TESTS_DIR ${NIFLY_DIR}/tests)

--- a/include/Object3d.hpp
+++ b/include/Object3d.hpp
@@ -18,7 +18,7 @@ constexpr float EPSILON = 0.0001f;
 constexpr float PI = 3.141592f;
 constexpr float DEG2RAD = PI / 180.0f;
 
-inline constexpr bool FloatsAreNearlyEqual(float a, float b) {
+inline bool FloatsAreNearlyEqual(float a, float b) {
 	float scale = std::max(std::max(std::fabs(a), std::fabs(b)), 1.0f);
 	return std::fabs(a - b) <= EPSILON * scale;
 }
@@ -251,7 +251,7 @@ struct Vector3 {
 
 	constexpr float dot(const Vector3& other) const { return x * other.x + y * other.y + z * other.z; }
 
-	constexpr float DistanceTo(const Vector3& target) const {
+	float DistanceTo(const Vector3& target) const {
 		float dx = target.x - x;
 		float dy = target.y - y;
 		float dz = target.z - z;
@@ -291,16 +291,16 @@ struct Vector3 {
 			z = 0.0f;
 	}
 
-	constexpr bool IsNearlyEqualTo(const Vector3& other) const {
+	bool IsNearlyEqualTo(const Vector3& other) const {
 		return FloatsAreNearlyEqual(x, other.x) && FloatsAreNearlyEqual(y, other.y)
 			   && FloatsAreNearlyEqual(z, other.z);
 	}
 
 	constexpr float length2() const { return x * x + y * y + z * z; }
 
-	constexpr float length() const { return std::sqrt(x * x + y * y + z * z); }
+	float length() const { return std::sqrt(x * x + y * y + z * z); }
 
-	constexpr float DistanceToSegment(const Vector3& p1, const Vector3& p2) const {
+	float DistanceToSegment(const Vector3& p1, const Vector3& p2) const {
 		Vector3 segvec(p2 - p1);
 		Vector3 diffp1(*this - p1);
 		float dp = segvec.dot(diffp1);
@@ -567,7 +567,7 @@ public:
 		return canRot;
 	}
 
-	constexpr bool IsNearlyEqualTo(const Matrix3& other) const {
+	bool IsNearlyEqualTo(const Matrix3& other) const {
 		return rows[0].IsNearlyEqualTo(other.rows[0]) && rows[1].IsNearlyEqualTo(other.rows[1])
 			   && rows[2].IsNearlyEqualTo(other.rows[2]);
 	}
@@ -593,9 +593,9 @@ class Matrix4 {
 	float m[16]{};
 
 public:
-	constexpr Matrix4() { Identity(); }
+	constexpr Matrix4(): m{1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f} {}
 
-	constexpr Matrix4(const std::vector<Vector3>& mat33) { Set(mat33); }
+	Matrix4(const std::vector<Vector3>& mat33) { Set(mat33); }
 
 	void Set(Vector3 mat33[3]) {
 		m[0] = mat33[0].x;
@@ -1069,7 +1069,7 @@ struct MatTransform {
 	// t3.ApplyTransform(v) == t1.ApplyTransform(t2.ApplyTransform(v)).
 	MatTransform ComposeTransforms(const MatTransform& other) const;
 
-	constexpr bool IsNearlyEqualTo(const MatTransform& other) const {
+	bool IsNearlyEqualTo(const MatTransform& other) const {
 		return translation.IsNearlyEqualTo(other.translation) && rotation.IsNearlyEqualTo(other.rotation)
 			   && FloatsAreNearlyEqual(scale, other.scale);
 	}

--- a/include/Object3d.hpp
+++ b/include/Object3d.hpp
@@ -207,7 +207,8 @@ struct Vector3 {
 		return (*this);
 	}
 	constexpr Vector3 operator*(int val) const {
-		return Vector3(x * val, y * val, z * val);
+		float v = static_cast<float>(val);
+		return Vector3(x * v, y * v, z * v);
 	}
 	Vector3& operator/=(int val) {
 		auto v = static_cast<float>(val);
@@ -217,7 +218,8 @@ struct Vector3 {
 		return (*this);
 	}
 	constexpr Vector3 operator/(int val) const {
-		return Vector3(x / val, y / val, z / val);
+		float v = static_cast<float>(val);
+		return Vector3(x / v, y / v, z / v);
 	}
 
 	Vector3& operator*=(uint32_t val) {
@@ -228,7 +230,8 @@ struct Vector3 {
 		return (*this);
 	}
 	constexpr Vector3 operator*(uint32_t val) const {
-		return Vector3(x * val, y * val, z * val);
+		float v = static_cast<float>(val);
+		return Vector3(x * v, y * v, z * v);
 	}
 	Vector3& operator/=(uint32_t val) {
 		auto v = static_cast<float>(val);
@@ -238,7 +241,8 @@ struct Vector3 {
 		return (*this);
 	}
 	constexpr Vector3 operator/(uint32_t val) const {
-		return Vector3(x / val, y / val, z / val);
+		float v = static_cast<float>(val);
+		return Vector3(x / v, y / v, z / v);
 	}
 
 	constexpr Vector3 cross(const Vector3& other) const {

--- a/include/Object3d.hpp
+++ b/include/Object3d.hpp
@@ -161,22 +161,44 @@ struct Vector3 {
 	constexpr Vector3 operator+(const Vector3& other) const {
 		return Vector3(x + other.x, y + other.y, z + other.z);
 	}
+	[[deprecated("Replaced by ComponentMultiplyBy; should not have been an operator")]]
 	Vector3& operator*=(const Vector3& other) {
 		x *= other.x;
 		y *= other.y;
 		z *= other.z;
 		return (*this);
 	}
+	Vector3& ComponentMultiplyBy(const Vector3& other) {
+		x *= other.x;
+		y *= other.y;
+		z *= other.z;
+		return (*this);
+	}
+	[[deprecated("Replaced by ComponentMultiply; should not have been an operator")]]
 	constexpr Vector3 operator*(const Vector3& other) const {
 		return Vector3(x * other.x, y * other.y, z * other.z);
 	}
+	constexpr Vector3 ComponentMultiply(const Vector3& other) const {
+		return Vector3(x * other.x, y * other.y, z * other.z);
+	}
+	[[deprecated("Replaced by ComponentDivideBy; should not have been an operator")]]
 	Vector3& operator/=(const Vector3& other) {
 		x /= other.x;
 		y /= other.y;
 		z /= other.z;
 		return (*this);
 	}
+	Vector3& ComponentDivideBy(const Vector3& other) {
+		x /= other.x;
+		y /= other.y;
+		z /= other.z;
+		return (*this);
+	}
+	[[deprecated("Replaced by ComponentDivide; should not have been an operator")]]
 	constexpr Vector3 operator/(const Vector3& other) const {
+		return Vector3(x / other.x, y / other.y, z / other.z);
+	}
+	constexpr Vector3 ComponentDivide(const Vector3& other) const {
 		return Vector3(x / other.x, y / other.y, z / other.z);
 	}
 
@@ -517,6 +539,7 @@ public:
 					   rows[2][0] * v.x + rows[2][1] * v.y + rows[2][2] * v.z);
 	}
 
+	[[deprecated("Should not have been an operator; replace with multiplying by Vector3(f,f,f)")]]
 	constexpr Vector3 operator*(const float f) const {
 		return Vector3(rows[0][0] * f + rows[0][1] * f + rows[0][2] * f,
 					   rows[1][0] * f + rows[1][1] * f + rows[1][2] * f,
@@ -1038,7 +1061,8 @@ struct MatTransform {
 		return m;
 	}
 
-	Vector3 GetVector() const { return translation + rotation * scale; }
+	[[deprecated("Does something nonsensical")]]
+	Vector3 GetVector() const { return translation + rotation * Vector3(scale, scale, scale); }
 
 	// ApplyTransform applies this MatTransform to a position vector v by
 	// first scaling v, then rotating the result of that, and then

--- a/include/Object3d.hpp
+++ b/include/Object3d.hpp
@@ -131,7 +131,7 @@ struct Vector3 {
 		z /= d;
 	}
 
-	constexpr uint32_t hash() const {
+	uint32_t hash() const {
 		static_assert(sizeof(float) == sizeof(uint32_t));
 		const uint32_t* h = reinterpret_cast<const uint32_t*>(this);
 		uint32_t f = (h[0] + h[1] * 11 - h[2] * 17) & 0x7fffffff;

--- a/include/Object3d.hpp
+++ b/include/Object3d.hpp
@@ -18,7 +18,7 @@ constexpr float EPSILON = 0.0001f;
 constexpr float PI = 3.141592f;
 constexpr float DEG2RAD = PI / 180.0f;
 
-inline bool FloatsAreNearlyEqual(float a, float b) {
+inline constexpr bool FloatsAreNearlyEqual(float a, float b) {
 	float scale = std::max(std::max(std::fabs(a), std::fabs(b)), 1.0f);
 	return std::fabs(a - b) <= EPSILON * scale;
 }
@@ -27,10 +27,10 @@ float CalcMedianOfFloats(const std::vector<float>& data);
 
 // Vector with 2 float components (uv)
 struct Vector2 {
-	float u;
-	float v;
+	float u = 0.0f;
+	float v = 0.0f;
 
-	Vector2() { u = v = 0.0f; }
+	Vector2() = default;
 	Vector2(float U, float V) {
 		u = U;
 		v = V;
@@ -102,13 +102,13 @@ struct Vector3 {
 		, y(Y)
 		, z(Z) {}
 
-	float& operator[](int ind) { return ind ? (ind == 2 ? z : y) : x; }
-	float operator[](int ind) const { return ind ? (ind == 2 ? z : y) : x; }
+	constexpr float& operator[](int ind) { return ind ? (ind == 2 ? z : y) : x; }
+	constexpr float operator[](int ind) const { return ind ? (ind == 2 ? z : y) : x; }
 
 	void Zero() { x = y = z = 0.0f; }
 
 	// With bUseEpsilon, uses nifly::EPSILON for a nearly zero comparison.
-	bool IsZero(bool bUseEpsilon = false) const {
+	constexpr bool IsZero(bool bUseEpsilon = false) const {
 		if (bUseEpsilon) {
 			if (std::fabs(x) < EPSILON && std::fabs(y) < EPSILON && std::fabs(z) < EPSILON)
 				return true;
@@ -131,17 +131,17 @@ struct Vector3 {
 		z /= d;
 	}
 
-	uint32_t hash() const {
+	constexpr uint32_t hash() const {
 		static_assert(sizeof(float) == sizeof(uint32_t));
 		const uint32_t* h = reinterpret_cast<const uint32_t*>(this);
 		uint32_t f = (h[0] + h[1] * 11 - h[2] * 17) & 0x7fffffff;
 		return (f >> 22) ^ (f >> 12) ^ (f);
 	}
 
-	bool operator==(const Vector3& other) const {
+	constexpr bool operator==(const Vector3& other) const {
 		return x == other.x && y == other.y && z == other.z;
 	}
-	bool operator!=(const Vector3& other) const { return !(*this == other); }
+	constexpr bool operator!=(const Vector3& other) const { return !(*this == other); }
 
 	Vector3& operator-=(const Vector3& other) {
 		x -= other.x;
@@ -149,10 +149,8 @@ struct Vector3 {
 		z -= other.z;
 		return (*this);
 	}
-	Vector3 operator-(const Vector3& other) const {
-		Vector3 tmp = (*this);
-		tmp -= other;
-		return tmp;
+	constexpr Vector3 operator-(const Vector3& other) const {
+		return Vector3(x - other.x, y - other.y, z - other.z);
 	}
 	Vector3& operator+=(const Vector3& other) {
 		x += other.x;
@@ -160,10 +158,8 @@ struct Vector3 {
 		z += other.z;
 		return (*this);
 	}
-	Vector3 operator+(const Vector3& other) const {
-		Vector3 tmp = (*this);
-		tmp += other;
-		return tmp;
+	constexpr Vector3 operator+(const Vector3& other) const {
+		return Vector3(x + other.x, y + other.y, z + other.z);
 	}
 	Vector3& operator*=(const Vector3& other) {
 		x *= other.x;
@@ -171,10 +167,8 @@ struct Vector3 {
 		z *= other.z;
 		return (*this);
 	}
-	Vector3 operator*(const Vector3& other) const {
-		Vector3 tmp = (*this);
-		tmp *= other;
-		return tmp;
+	constexpr Vector3 operator*(const Vector3& other) const {
+		return Vector3(x * other.x, y * other.y, z * other.z);
 	}
 	Vector3& operator/=(const Vector3& other) {
 		x /= other.x;
@@ -182,10 +176,8 @@ struct Vector3 {
 		z /= other.z;
 		return (*this);
 	}
-	Vector3 operator/(const Vector3& other) const {
-		Vector3 tmp = (*this);
-		tmp /= other;
-		return tmp;
+	constexpr Vector3 operator/(const Vector3& other) const {
+		return Vector3(x / other.x, y / other.y, z / other.z);
 	}
 
 	Vector3& operator*=(float val) {
@@ -194,10 +186,8 @@ struct Vector3 {
 		z *= val;
 		return (*this);
 	}
-	Vector3 operator*(float val) const {
-		Vector3 tmp = (*this);
-		tmp *= val;
-		return tmp;
+	constexpr Vector3 operator*(float val) const {
+		return Vector3(x * val, y * val, z * val);
 	}
 	Vector3& operator/=(float val) {
 		x /= val;
@@ -205,10 +195,8 @@ struct Vector3 {
 		z /= val;
 		return (*this);
 	}
-	Vector3 operator/(float val) const {
-		Vector3 tmp = (*this);
-		tmp /= val;
-		return tmp;
+	constexpr Vector3 operator/(float val) const {
+		return Vector3(x / val, y / val, z / val);
 	}
 
 	Vector3& operator*=(int val) {
@@ -218,10 +206,8 @@ struct Vector3 {
 		z *= v;
 		return (*this);
 	}
-	Vector3 operator*(int val) const {
-		Vector3 tmp = (*this);
-		tmp *= val;
-		return tmp;
+	constexpr Vector3 operator*(int val) const {
+		return Vector3(x * val, y * val, z * val);
 	}
 	Vector3& operator/=(int val) {
 		auto v = static_cast<float>(val);
@@ -230,10 +216,8 @@ struct Vector3 {
 		z /= v;
 		return (*this);
 	}
-	Vector3 operator/(int val) const {
-		Vector3 tmp = (*this);
-		tmp /= val;
-		return tmp;
+	constexpr Vector3 operator/(int val) const {
+		return Vector3(x / val, y / val, z / val);
 	}
 
 	Vector3& operator*=(uint32_t val) {
@@ -243,10 +227,8 @@ struct Vector3 {
 		z *= v;
 		return (*this);
 	}
-	Vector3 operator*(uint32_t val) const {
-		Vector3 tmp = (*this);
-		tmp *= val;
-		return tmp;
+	constexpr Vector3 operator*(uint32_t val) const {
+		return Vector3(x * val, y * val, z * val);
 	}
 	Vector3& operator/=(uint32_t val) {
 		auto v = static_cast<float>(val);
@@ -255,13 +237,11 @@ struct Vector3 {
 		z /= v;
 		return (*this);
 	}
-	Vector3 operator/(uint32_t val) const {
-		Vector3 tmp = (*this);
-		tmp /= val;
-		return tmp;
+	constexpr Vector3 operator/(uint32_t val) const {
+		return Vector3(x / val, y / val, z / val);
 	}
 
-	Vector3 cross(const Vector3& other) const {
+	constexpr Vector3 cross(const Vector3& other) const {
 		Vector3 tmp;
 		tmp.x = y * other.z - z * other.y;
 		tmp.y = z * other.x - x * other.z;
@@ -269,16 +249,16 @@ struct Vector3 {
 		return tmp;
 	}
 
-	float dot(const Vector3& other) const { return x * other.x + y * other.y + z * other.z; }
+	constexpr float dot(const Vector3& other) const { return x * other.x + y * other.y + z * other.z; }
 
-	float DistanceTo(const Vector3& target) const {
+	constexpr float DistanceTo(const Vector3& target) const {
 		float dx = target.x - x;
 		float dy = target.y - y;
 		float dz = target.z - z;
 		return static_cast<float>(std::sqrt(dx * dx + dy * dy + dz * dz));
 	}
 
-	float DistanceSquaredTo(const Vector3& target) const {
+	constexpr float DistanceSquaredTo(const Vector3& target) const {
 		float dx = target.x - x;
 		float dy = target.y - y;
 		float dz = target.z - z;
@@ -311,16 +291,16 @@ struct Vector3 {
 			z = 0.0f;
 	}
 
-	bool IsNearlyEqualTo(const Vector3& other) const {
+	constexpr bool IsNearlyEqualTo(const Vector3& other) const {
 		return FloatsAreNearlyEqual(x, other.x) && FloatsAreNearlyEqual(y, other.y)
 			   && FloatsAreNearlyEqual(z, other.z);
 	}
 
-	float length2() const { return x * x + y * y + z * z; }
+	constexpr float length2() const { return x * x + y * y + z * z; }
 
-	float length() const { return std::sqrt(x * x + y * y + z * z); }
+	constexpr float length() const { return std::sqrt(x * x + y * y + z * z); }
 
-	float DistanceToSegment(const Vector3& p1, const Vector3& p2) const {
+	constexpr float DistanceToSegment(const Vector3& p1, const Vector3& p2) const {
 		Vector3 segvec(p2 - p1);
 		Vector3 diffp1(*this - p1);
 		float dp = segvec.dot(diffp1);
@@ -332,7 +312,7 @@ struct Vector3 {
 	}
 };
 
-inline Vector3 operator*(float f, const Vector3& v) {
+inline constexpr Vector3 operator*(float f, const Vector3& v) {
 	return Vector3(f * v.x, f * v.y, f * v.z);
 }
 
@@ -355,20 +335,20 @@ struct Vector4 {
 
 // Color with 3 float components (rgb)
 struct Color3 {
-	float r;
-	float g;
-	float b;
+	float r = 0.0f;
+	float g = 0.0f;
+	float b = 0.0f;
 
-	Color3() { r = g = b = 0.0f; }
-	Color3(float r_, float g_, float b_)
+	constexpr Color3() = default;
+	constexpr Color3(float r_, float g_, float b_)
 		: r(r_)
 		, g(g_)
 		, b(b_) {}
 
-	bool operator==(const Color3& other) {
+	constexpr bool operator==(const Color3& other) {
 		return r == other.r && g == other.g && b == other.b;
 	}
-	bool operator!=(const Color3& other) { return !(*this == other); }
+	constexpr bool operator!=(const Color3& other) { return !(*this == other); }
 
 	Color3& operator*=(float val) {
 		r *= val;
@@ -376,10 +356,8 @@ struct Color3 {
 		b *= val;
 		return *this;
 	}
-	Color3 operator*(float val) const {
-		Color3 tmp = *this;
-		tmp *= val;
-		return tmp;
+	constexpr Color3 operator*(float val) const {
+		return Color3(r * val, g * val, b * val);
 	}
 
 	Color3& operator/=(float val) {
@@ -388,31 +366,29 @@ struct Color3 {
 		b /= val;
 		return *this;
 	}
-	Color3 operator/(float val) const {
-		Color3 tmp = *this;
-		tmp /= val;
-		return tmp;
+	constexpr Color3 operator/(float val) const {
+		return Color3(r / val, g / val, b / val);
 	}
 };
 
 // Color with 4 float components (rgba)
 struct Color4 {
-	float r;
-	float g;
-	float b;
-	float a;
+	float r = 0.0f;
+	float g = 0.0f;
+	float b = 0.0f;
+	float a = 0.0f;
 
-	Color4() { r = g = b = a = 0.0f; }
-	Color4(float r_, float g_, float b_, float a_)
+	constexpr Color4() = default;
+	constexpr Color4(float r_, float g_, float b_, float a_)
 		: r(r_)
 		, g(g_)
 		, b(b_)
 		, a(a_) {}
 
-	bool operator==(const Color4& other) {
+	constexpr bool operator==(const Color4& other) {
 		return r == other.r && g == other.g && b == other.b && a == other.a;
 	}
-	bool operator!=(const Color4& other) { return !(*this == other); }
+	constexpr bool operator!=(const Color4& other) { return !(*this == other); }
 
 	Color4& operator*=(float val) {
 		r *= val;
@@ -421,10 +397,8 @@ struct Color4 {
 		a *= val;
 		return *this;
 	}
-	Color4 operator*(float val) const {
-		Color4 tmp = *this;
-		tmp *= val;
-		return tmp;
+	constexpr Color4 operator*(float val) const {
+		return Color4(r * val, g * val, b * val, a * val);
 	}
 
 	Color4& operator/=(float val) {
@@ -434,10 +408,8 @@ struct Color4 {
 		a /= val;
 		return *this;
 	}
-	Color4 operator/(float val) const {
-		Color4 tmp = *this;
-		tmp /= val;
-		return tmp;
+	constexpr Color4 operator/(float val) const {
+		return Color4(r / val, g / val, b / val, a / val);
 	}
 };
 
@@ -468,15 +440,21 @@ class Matrix3 {
 	Vector3 rows[3] = {Vector3(1.0f, 0.0f, 0.0f), Vector3(0.0f, 1.0f, 0.0f), Vector3(0.0f, 0.0f, 1.0f)};
 
 public:
-	Vector3& operator[](int index) { return rows[index]; }
+	constexpr Matrix3() {}
+	constexpr Matrix3(const Vector3& r1, const Vector3& r2, const Vector3& r3)
+		: rows{r1, r2, r3} {}
+	constexpr Matrix3(float m00, float m01, float m02, float m10, float m11, float m12, float m20, float m21, float m22)
+		: rows{Vector3(m00, m01, m02), Vector3(m10, m11, m12), Vector3(m20, m21, m22)} {}
 
-	const Vector3& operator[](int index) const { return rows[index]; }
+	constexpr Vector3& operator[](int index) { return rows[index]; }
 
-	bool operator==(const Matrix3& other) {
+	constexpr const Vector3& operator[](int index) const { return rows[index]; }
+
+	constexpr bool operator==(const Matrix3& other) {
 		return rows[0] == other[0] && rows[1] == other[1] && rows[2] == other[2];
 	}
 
-	bool IsIdentity() { return *this == Matrix3(); }
+	constexpr bool IsIdentity() { return *this == Matrix3(); }
 
 	Matrix3& Identity() {
 		//1.0f, 0.0f, 0.0f
@@ -492,30 +470,22 @@ public:
 		return *this;
 	}
 
-	Matrix3 operator+(const Matrix3& other) const {
-		Matrix3 res(*this);
-		res += other;
-		return res;
+	constexpr Matrix3 operator+(const Matrix3& other) const {
+		return Matrix3(rows[0] + other[0], rows[1] + other[1], rows[2] + other[2]);
 	}
 
 	Matrix3& operator+=(const Matrix3& other) {
-		rows[0] += other[0];
-		rows[1] += other[1];
-		rows[2] += other[2];
-		return (*this);
+		*this = *this + other;
+		return *this;
 	}
 
-	Matrix3 operator-(const Matrix3& other) const {
-		Matrix3 res(*this);
-		res -= other;
-		return res;
+	constexpr Matrix3 operator-(const Matrix3& other) const {
+		return Matrix3(rows[0] - other[0], rows[1] - other[1], rows[2] - other[2]);
 	}
 
 	Matrix3& operator-=(const Matrix3& other) {
-		rows[0] -= other[0];
-		rows[1] -= other[1];
-		rows[2] -= other[2];
-		return (*this);
+		*this = *this - other;
+		return *this;
 	}
 
 	Matrix3& operator*=(const Matrix3& other) {
@@ -523,7 +493,7 @@ public:
 		return *this;
 	}
 
-	Matrix3 operator*(const Matrix3& o) const {
+	constexpr Matrix3 operator*(const Matrix3& o) const {
 		Matrix3 res;
 		res[0][0] = rows[0][0] * o[0][0] + rows[0][1] * o[1][0] + rows[0][2] * o[2][0];
 		res[0][1] = rows[0][0] * o[0][1] + rows[0][1] * o[1][1] + rows[0][2] * o[2][1];
@@ -537,19 +507,19 @@ public:
 		return res;
 	}
 
-	Vector3 operator*(const Vector3& v) const {
+	constexpr Vector3 operator*(const Vector3& v) const {
 		return Vector3(rows[0][0] * v.x + rows[0][1] * v.y + rows[0][2] * v.z,
 					   rows[1][0] * v.x + rows[1][1] * v.y + rows[1][2] * v.z,
 					   rows[2][0] * v.x + rows[2][1] * v.y + rows[2][2] * v.z);
 	}
 
-	Vector3 operator*(const float f) const {
+	constexpr Vector3 operator*(const float f) const {
 		return Vector3(rows[0][0] * f + rows[0][1] * f + rows[0][2] * f,
 					   rows[1][0] * f + rows[1][1] * f + rows[1][2] * f,
 					   rows[2][0] * f + rows[2][1] * f + rows[2][2] * f);
 	}
 
-	Matrix3 Transpose() const {
+	constexpr Matrix3 Transpose() const {
 		Matrix3 res;
 		res[0][0] = rows[0][0];
 		res[0][1] = rows[1][0];
@@ -597,7 +567,7 @@ public:
 		return canRot;
 	}
 
-	bool IsNearlyEqualTo(const Matrix3& other) const {
+	constexpr bool IsNearlyEqualTo(const Matrix3& other) const {
 		return rows[0].IsNearlyEqualTo(other.rows[0]) && rows[1].IsNearlyEqualTo(other.rows[1])
 			   && rows[2].IsNearlyEqualTo(other.rows[2]);
 	}
@@ -623,9 +593,9 @@ class Matrix4 {
 	float m[16]{};
 
 public:
-	Matrix4() { Identity(); }
+	constexpr Matrix4() { Identity(); }
 
-	Matrix4(const std::vector<Vector3>& mat33) { Set(mat33); }
+	constexpr Matrix4(const std::vector<Vector3>& mat33) { Set(mat33); }
 
 	void Set(Vector3 mat33[3]) {
 		m[0] = mat33[0].x;
@@ -671,7 +641,8 @@ public:
 		m[row * 4 + 2] = inVec.z;
 	}
 
-	float& operator[](int index) { return m[index]; }
+	constexpr float& operator[](int index) { return m[index]; }
+	constexpr float operator[](int index) const { return m[index]; }
 
 	bool operator==(const Matrix4& other) { return (std::equal(m, m + sizeof m / sizeof *m, other.m)); }
 
@@ -775,9 +746,10 @@ public:
 				- (t[2] * t[4] * t[6] + t[1] * t[3] * t[8] + t[0] * t[5] * t[7]));
 	}
 
-	Matrix4 operator+(const Matrix4& other) const {
+	constexpr Matrix4 operator+(const Matrix4& other) const {
 		Matrix4 t(*this);
-		t += other;
+		for (int i = 0; i < 16; i++)
+			t[i] += other[i];
 		return t;
 	}
 	Matrix4& operator+=(const Matrix4& other) {
@@ -786,9 +758,10 @@ public:
 
 		return (*this);
 	}
-	Matrix4 operator-(const Matrix4& other) const {
+	constexpr Matrix4 operator-(const Matrix4& other) const {
 		Matrix4 t(*this);
-		t -= other;
+		for (int i = 0; i < 16; i++)
+			t[i] -= other[i];
 		return t;
 	}
 	Matrix4& operator-=(const Matrix4& other) {
@@ -797,7 +770,7 @@ public:
 
 		return (*this);
 	}
-	Vector3 operator*(const Vector3& v) const {
+	constexpr Vector3 operator*(const Vector3& v) const {
 		return Vector3(m[0] * v.x + m[1] * v.y + m[2] * v.z + m[3],
 					   m[4] * v.x + m[5] * v.y + m[6] * v.z + m[7],
 					   m[8] * v.x + m[9] * v.y + m[10] * v.z + m[11]);
@@ -822,7 +795,7 @@ public:
 		t *= other;
 		return t;
 	}
-	Matrix4 operator*(float val) {
+	constexpr Matrix4 operator*(float val) {
 		Matrix4 t(*this);
 		for (int i = 0; i < 16; i++)
 			t[i] *= val;
@@ -925,9 +898,9 @@ struct BoundingSphere {
 	Vector3 center;
 	float radius = 0.0f;
 
-	BoundingSphere() {}
+	constexpr BoundingSphere() {}
 
-	BoundingSphere(const Vector3& center_, const float radius_)
+	constexpr BoundingSphere(const Vector3& center_, const float radius_)
 		: center(center_)
 		, radius(radius_) {}
 
@@ -943,14 +916,13 @@ struct Quaternion {
 	float y;
 	float z;
 
-	Quaternion() {
-		w = 1.0f;
-		x = 0.0f;
-		y = 0.0f;
-		z = 0.0f;
-	}
+	constexpr Quaternion()
+		: w(1.0f)
+		, x(0.0f)
+		, y(0.0f)
+		, z(0.0f) {}
 
-	Quaternion(float w_, float x_, float y_, float z_)
+	constexpr Quaternion(float w_, float x_, float y_, float z_)
 		: w(w_)
 		, x(x_)
 		, y(y_)
@@ -964,14 +936,13 @@ struct QuaternionXYZW {
 	float z;
 	float w;
 
-	QuaternionXYZW() {
-		x = 0.0f;
-		y = 0.0f;
-		z = 0.0f;
-		w = 1.0f;
-	}
+	constexpr QuaternionXYZW()
+		: x(0.0f)
+		, y(0.0f)
+		, z(0.0f)
+		, w(1.0f) {}
 
-	QuaternionXYZW(float x_, float y_, float z_, float w_)
+	constexpr QuaternionXYZW(float x_, float y_, float z_, float w_)
 		: x(x_)
 		, y(y_)
 		, z(z_)
@@ -1020,7 +991,7 @@ struct MatTransform {
 	bool ToEulerDegrees(float& y, float& p, float& r) const { return rotation.ToEulerDegrees(y, p, r); }
 
 	// Full matrix of translation, rotation and scale
-	Matrix4 ToMatrix() const {
+	constexpr Matrix4 ToMatrix() const {
 		Matrix4 mat;
 		mat[0] = rotation[0].x * scale;
 		mat[1] = rotation[0].y * scale;
@@ -1037,12 +1008,57 @@ struct MatTransform {
 		return mat;
 	}
 
+	// ToGLMMatrix: turns this transform into a glm::mat4x4.  This is
+	// basically the same as ToMatrix above, except glm::mat4x4 stores its
+	// data in column-major form instead of row-major like everything else.
+	// To call, do xform.ToGLMMatrix<glm::mat4x4>();
+	template<typename Mat>
+	constexpr Mat ToGLMMatrix() const {
+		Mat m;
+		m[0][0] = rotation[0][0] * scale;
+		m[0][1] = rotation[1][0] * scale;
+		m[0][2] = rotation[2][0] * scale;
+		m[0][3] = 0.0f;
+		m[1][0] = rotation[0][1] * scale;
+		m[1][1] = rotation[1][1] * scale;
+		m[1][2] = rotation[2][1] * scale;
+		m[1][3] = 0.0f;
+		m[2][0] = rotation[0][2] * scale;
+		m[2][1] = rotation[1][2] * scale;
+		m[2][2] = rotation[2][2] * scale;
+		m[2][3] = 0.0f;
+		m[3][0] = translation.x;
+		m[3][1] = translation.y;
+		m[3][2] = translation.z;
+		m[3][3] = 1.0f;
+		return m;
+	}
+
 	Vector3 GetVector() const { return translation + rotation * scale; }
 
-	// ApplyTransform applies this MatTransform to a vector v by first
-	// scaling v, then rotating the result of that, then translating the
-	// result of that.
-	Vector3 ApplyTransform(const Vector3& v) const;
+	// ApplyTransform applies this MatTransform to a position vector v by
+	// first scaling v, then rotating the result of that, and then
+	// translating the result of that.
+	constexpr Vector3 ApplyTransform(const Vector3& pos) const {
+		return translation + rotation * (pos * scale);
+	}
+
+	// ApplyTransformToDiff applies this transform to a position difference
+	// (or offset) vector.
+	constexpr Vector3 ApplyTransformToDiff(const Vector3& diff) const {
+		return rotation * (diff * scale);
+	}
+
+	// ApplyTransformToDir applies this transform to a direction unit
+	// vector or normal.
+	constexpr Vector3 ApplyTransformToDir(const Vector3& dir) const {
+		return rotation * dir;
+	}
+
+	// ApplyTransformToDist applies this transform to a distance.
+	constexpr float ApplyTransformToDist(float d) const {
+		return scale * d;
+	}
 
 	// Note that InverseTransform will return garbage if "rotation"
 	// is not invertible or scale is 0.
@@ -1053,7 +1069,7 @@ struct MatTransform {
 	// t3.ApplyTransform(v) == t1.ApplyTransform(t2.ApplyTransform(v)).
 	MatTransform ComposeTransforms(const MatTransform& other) const;
 
-	bool IsNearlyEqualTo(const MatTransform& other) const {
+	constexpr bool IsNearlyEqualTo(const MatTransform& other) const {
 		return translation.IsNearlyEqualTo(other.translation) && rotation.IsNearlyEqualTo(other.rotation)
 			   && FloatsAreNearlyEqual(scale, other.scale);
 	}
@@ -1068,13 +1084,10 @@ struct Edge {
 	uint16_t p1;
 	uint16_t p2;
 
-	Edge() { p1 = p2 = 0; }
-	Edge(uint16_t P1, uint16_t P2) {
-		p1 = P1;
-		p2 = P2;
-	}
+	constexpr Edge(): p1(0), p2(0) {}
+	constexpr Edge(uint16_t P1, uint16_t P2): p1(P1), p2(P2) {}
 
-	bool CompareIndices(const Edge& o) { return (p1 == o.p1 && p2 == o.p2) || (p1 == o.p2 && p2 == o.p1); }
+	constexpr bool CompareIndices(const Edge& o) { return (p1 == o.p1 && p2 == o.p2) || (p1 == o.p2 && p2 == o.p1); }
 };
 
 // Triangle with uint16_t point indices
@@ -1083,12 +1096,8 @@ struct Triangle {
 	uint16_t p2;
 	uint16_t p3;
 
-	Triangle() { p1 = p2 = p3 = 0; }
-	Triangle(uint16_t P1, uint16_t P2, uint16_t P3) {
-		p1 = P1;
-		p2 = P2;
-		p3 = P3;
-	}
+	constexpr Triangle(): p1(0), p2(0), p3(0) {}
+	constexpr Triangle(uint16_t P1, uint16_t P2, uint16_t P3): p1(P1), p2(P2), p3(P3) {}
 
 	void set(uint16_t P1, uint16_t P2, uint16_t P3) {
 		p1 = P1;
@@ -1127,7 +1136,7 @@ struct Triangle {
 
 	float AxisMidPointZ(const Vector3* vertref) const { return (vertref[p1].z + vertref[p2].z + vertref[p3].z) / 3.0f; }
 
-	Edge GetEdge(int i) const {
+	constexpr Edge GetEdge(int i) const {
 		if (i == 0)
 			return Edge(p1, p2);
 		else if (i == 1)
@@ -1136,11 +1145,11 @@ struct Triangle {
 			return Edge(p3, p1);
 	}
 
-	bool HasVertex(uint16_t p) const {
+	constexpr bool HasVertex(uint16_t p) const {
 		return p == p1 || p == p2 || p == p3;
 	}
 
-	bool HasOrientedEdge(const Edge& e) const {
+	constexpr bool HasOrientedEdge(const Edge& e) const {
 		return (e.p1 == p1 && e.p2 == p2) || (e.p1 == p2 && e.p2 == p3) || (e.p1 == p3 && e.p2 == p1);
 	}
 
@@ -1318,7 +1327,7 @@ struct Triangle {
 	uint16_t& operator[](int ind) { return ind ? (ind == 2 ? p3 : p2) : p1; }
 	const uint16_t& operator[](int ind) const { return ind ? (ind == 2 ? p3 : p2) : p1; }
 
-	bool operator<(const Triangle& other) const {
+	constexpr bool operator<(const Triangle& other) const {
 		int d = 0;
 		if (d == 0)
 			d = p1 - other.p1;
@@ -1329,11 +1338,11 @@ struct Triangle {
 		return d < 0;
 	}
 
-	bool operator==(const Triangle& other) const {
+	constexpr bool operator==(const Triangle& other) const {
 		return (p1 == other.p1 && p2 == other.p2 && p3 == other.p3);
 	}
 
-	bool CompareIndices(const Triangle& other) const {
+	constexpr bool CompareIndices(const Triangle& other) const {
 		return ((p1 == other.p1 || p1 == other.p2 || p1 == other.p3)
 				&& (p2 == other.p1 || p2 == other.p2 || p2 == other.p3)
 				&& (p3 == other.p1 || p3 == other.p2 || p3 == other.p3));
@@ -1349,7 +1358,7 @@ struct Triangle {
 	}
 };
 
-inline bool operator==(const Edge& t1, const Edge& t2) {
+inline constexpr bool operator==(const Edge& t1, const Edge& t2) {
 	return ((t1.p1 == t2.p1) && (t1.p2 == t2.p2));
 }
 

--- a/src/Object3d.cpp
+++ b/src/Object3d.cpp
@@ -312,10 +312,6 @@ bool Matrix3::ToEulerAngles(float& y, float& p, float& r) const {
 	return canRot;
 }
 
-Vector3 MatTransform::ApplyTransform(const Vector3& v) const {
-	return translation + rotation * (v * scale);
-}
-
 MatTransform MatTransform::InverseTransform() const {
 	MatTransform inv;
 	inv.rotation = rotation.Inverse();


### PR DESCRIPTION
- Added functions to MatTransform: ToGLMMatrix, ApplyTransformToDiff, ApplyTransformToDir, and ApplyTransformToDist.
- Made MatTransform::ApplyTransform an inline function.
- Added some constructors for Matrix3.
- Made many of the functions in Object3d.hpp constexpr.  For some, this necessitated changes to the implementation in order to comply with the rules for constexpr functions, but in no case was functionality changed.  I was not thorough; there are lots of functions that could still be made constexpr.