### PR TITLE
Templated kd_tree's index type

### DIFF
--- a/include/KDMatcher.hpp
+++ b/include/KDMatcher.hpp
@@ -121,7 +121,7 @@ public:
 class kd_query_result {
 public:
 	const Vector3* v;
-	uint16_t vertex_index;
+	uint32_t vertex_index;
 	float distance;
 	bool operator<(const kd_query_result& other) const { return distance < other.distance; }
 };
@@ -132,16 +132,16 @@ public:
 	class kd_node {
 	public:
 		const Vector3* p = nullptr;
-		uint16_t p_i = 0;
+		uint32_t p_i = 0;
 		std::unique_ptr<kd_node> less;
 		std::unique_ptr<kd_node> more;
 
-		kd_node(const Vector3* point, const uint16_t point_index) {
+		kd_node(const Vector3* point, const uint32_t point_index) {
 			p = point;
 			p_i = point_index;
 		}
 
-		void add(const Vector3* point, const uint16_t point_index, const uint32_t depth) {
+		void add(const Vector3* point, const uint32_t point_index, const uint32_t depth) {
 			uint32_t axis = depth % 3;
 			bool domore = false;
 			float dx = p->x - point->x;
@@ -265,17 +265,17 @@ public:
 	std::unique_ptr<kd_node> root;
 	std::vector<kd_query_result> queryResult;
 
-	kd_tree(const Vector3* points, const uint16_t count) {
+	kd_tree(const Vector3* points, const uint32_t count) {
 		if (count <= 0)
 			return;
 
-		uint16_t pointIndex = 0;
+		uint32_t pointIndex = 0;
 		root = std::make_unique<kd_node>(&points[0], pointIndex);
-		for (uint16_t i = 1; i < count; i++)
+		for (uint32_t i = 1; i < count; i++)
 			root->add(&points[i], i, 0);
 	}
 
-	uint16_t kd_nn(const Vector3* querypoint, const float radius) {
+	uint32_t kd_nn(const Vector3* querypoint, const float radius) {
 		float mindist = std::numeric_limits<float>().max();
 		if (radius > 0.0f)
 			mindist = radius;
@@ -284,7 +284,7 @@ public:
 		root->find_closest(querypoint, queryResult, radius, mindist);
 		std::sort(queryResult.begin(), queryResult.end());
 
-		return static_cast<uint16_t>(queryResult.size());
+		return static_cast<uint32_t>(queryResult.size());
 	}
 };
 } // namespace nifly


### PR DESCRIPTION
This change is necessary for kd_tree to be able to handle more than 65536 points, which could happen if it's processing a list of triangle centers (since triangle indices are not limited to 65536).

Unfortunately, this change will probably result in warnings being generated about uint32_t being converted to uint16_t.