### PR TITLE
Improved SortingMatcher so it'll work better at small scales.

### DIFF
--- a/include/KDMatcher.hpp
+++ b/include/KDMatcher.hpp
@@ -84,6 +84,13 @@ public:
 		if (cnt <= 0)
 			return;
 
+		// Determine overall scale of the point set so we can determine a
+		// good epsilon
+		float scale = 0.0f;
+		for (uint16_t i = 0; i < cnt; ++i)
+			scale = std::max(scale, std::max(std::fabs(pts[i].x), std::max(std::fabs(pts[i].y), std::fabs(pts[i].z))));
+		float epsilon = EPSILON * 0.01f * scale;
+
 		std::vector<uint16_t> inds(cnt);
 		for (uint16_t i = 0; i < cnt; ++i)
 			inds[i] = i;
@@ -97,14 +104,14 @@ public:
 
 			bool matched = false;
 			for (uint16_t mi = si + 1; mi < cnt; ++mi) {
-				if (pts[inds[mi]].x - pts[inds[si]].x >= EPSILON)
+				if (pts[inds[mi]].x - pts[inds[si]].x >= epsilon)
 					break;
 
 				if (used[mi])
 					continue;
-				if (std::fabs(pts[inds[si]].y - pts[inds[mi]].y) >= EPSILON)
+				if (std::fabs(pts[inds[si]].y - pts[inds[mi]].y) >= epsilon)
 					continue;
-				if (std::fabs(pts[inds[si]].z - pts[inds[mi]].z) >= EPSILON)
+				if (std::fabs(pts[inds[si]].z - pts[inds[mi]].z) >= epsilon)
 					continue;
 
 				if (!matched)


### PR DESCRIPTION
With textures off, and a shape scale of about .001 or lower, the normals were visibly incorrect in Outfit Studio.  This was because at these scales points were being determined to be welded when they shouldn't have been.  That was because SortingMatcher, which is used by CalcWeldVerts, had an epsilon that did not vary with scale.  This PR fixes that.