### PR TITLE
remove SLSF2_PACKED_TANGENT when converting headparts to LE

### DIFF
--- a/src/NifFile.cpp
+++ b/src/NifFile.cpp
@@ -1774,6 +1774,11 @@ OptResult NifFile::OptimizeFor(OptOptions& options) {
 						bslsp->SetVertexAlpha(false);
 					}
 
+					// this flag breaks LE headparts
+					if (options.headParts) {
+						bslsp->shaderFlags2 &= ~SLSF2_PACKED_TANGENT;
+					}
+
 					if (options.removeParallax) {
 						if (bslsp->GetShaderType() == BSLSP_PARALLAX) {
 							// Change type from parallax to default


### PR DESCRIPTION
> As it is, headparts need a fair amount of manual cleanup. Even having CAO just mass disable "packed tangent" would save a lot of clicking.

>  it's slsf2_packed_tangent ..in shader flag 2. if that is not unchecked in LE facegen, they will be completely messed up. be nice to have that automated because some newer followers have had like 20 head and hair parts, and u gotta uncheck that manually 

From CAO comments