### PR TITLE
Limit substring length in NiHeader::SetExportInfo

### DIFF
--- a/include/BasicTypes.hpp
+++ b/include/BasicTypes.hpp
@@ -1012,7 +1012,7 @@ public:
 
 	std::string GetExportInfo() const;
 
-	// Sets export info string (automatically split into three members after 256 characters each)
+	// Sets export info string (automatically split into three members after 254 characters each)
 	void SetExportInfo(const std::string& exportInfo);
 
 	// Sets pointer to all blocks in the file

--- a/src/BasicTypes.cpp
+++ b/src/BasicTypes.cpp
@@ -201,9 +201,9 @@ void NiHeader::SetExportInfo(const std::string& exportInfo) {
 	exportStrings[2] = &exportInfo3;
 
 	auto it = exportStrings.begin();
-	for (size_t i = 0; i < exportInfo.length() && it < exportStrings.end(); i += 256, ++it) {
-		if (i + 256 <= exportInfo.length())
-			(*it)->get() = exportInfo.substr(i, 256);
+	for (size_t i = 0; i < exportInfo.length() && it < exportStrings.end(); i += 254, ++it) {
+		if (i + 254 <= exportInfo.length())
+			(*it)->get() = exportInfo.substr(i, 254);
 		else
 			(*it)->get() = exportInfo.substr(i, exportInfo.length() - i);
 	}


### PR DESCRIPTION
When calling SetExportInfo with a string shorter than 255 to set only exportInfo1, the function works as expected. However, issues occur when attempting to set each member according to the comment above the declaration or when passing a string larger than 254 characters.

If one passes a string resized to 3 * 256 with the desired export items at position 0, 256, and 512 into SetExportInfo, the header's exportInfo members are set to 256 character strings containing the provided data, which appears correct initially. The issue occurs when NiString::Write is called on the export items; The string length is cast to a uint8_t and stored. The string is resized using the value of that integer, but since the string was set to 256 characters of the source by SetExportInfo and a uint8_t can't be larger than 255, the string is resized to 0. SetNullOutput is called with its default parameter and thus is set to true for these members so the uint8_t is incremented to 1. This is then written to the file along with the null terminator. This results in a nif with valid but empty export info items.

If the input string is set to one character shorter than a multiple of 256, the resulting nif will fail to load since the last exportInfo item to be set has a size of 255 during writing. The length is incremented to account for the null terminator, writing 0 for the size while the full string and null terminator are still written to the file.

Since a null terminated string whose size is stored as an 8-bit integer can only be 254 characters long, not including the null terminator, and since NiString::Write handles this logic by incrementing the size and writing a null terminator, NiHeader::SetExportInfo should only take a maximum of 254 characters from each position in the input string.

Edit: I was referring to SetExportInfo as SetExportItems for some reason