### PR TITLE
Fix BSGeometry virtual overrides and SkinAttach bone fallback

### DIFF
--- a/include/Geometry.hpp
+++ b/include/Geometry.hpp
@@ -652,6 +652,20 @@ public:
 	bool GetTriangles(std::vector<Triangle>& tris) const override;
 	void SetTriangles(const std::vector<Triangle>& tris) override;
 
+	bool IsSkinned() const override { return !skinInstanceRef.IsEmpty(); }
+
+	bool HasSkinInstance() const override { return !skinInstanceRef.IsEmpty(); }
+	NiBlockRef<NiBoneContainer>* SkinInstanceRef() override { return &skinInstanceRef; }
+	const NiBlockRef<NiBoneContainer>* SkinInstanceRef() const override { return &skinInstanceRef; }
+
+	bool HasShaderProperty() const override { return !shaderPropertyRef.IsEmpty(); }
+	NiBlockRef<NiShader>* ShaderPropertyRef() override { return &shaderPropertyRef; }
+	const NiBlockRef<NiShader>* ShaderPropertyRef() const override { return &shaderPropertyRef; }
+
+	bool HasAlphaProperty() const override { return !alphaPropertyRef.IsEmpty(); }
+	NiBlockRef<NiAlphaProperty>* AlphaPropertyRef() override { return &alphaPropertyRef; }
+	const NiBlockRef<NiAlphaProperty>* AlphaPropertyRef() const override { return &alphaPropertyRef; }
+
 	uint8_t MeshCount() { return (uint8_t) meshes.size();	}
 
 	// Flag 0x200 (512) on BSGeometry controls whether mesh data is embedded inline

--- a/src/NifFile.cpp
+++ b/src/NifFile.cpp
@@ -2445,13 +2445,24 @@ uint32_t NifFile::GetShapeBoneList(NiShape* shape, std::vector<std::string>& out
 		return 0;
 
 	auto skinInst = hdr.GetBlock<NiBoneContainer>(shape->SkinInstanceRef());
-	if (!skinInst)
-		return 0;
+	if (skinInst) {
+		for (auto& bone : skinInst->boneRefs) {
+			auto node = hdr.GetBlock(bone);
+			if (node)
+				outList.push_back(node->name.get());
+		}
+	}
 
-	for (auto& bone : skinInst->boneRefs) {
-		auto node = hdr.GetBlock(bone);
-		if (node)
-			outList.push_back(node->name.get());
+	// SF NIFs store bone names in SkinAttach extra data instead of NiNode refs
+	if (outList.empty()) {
+		for (auto& extraDataRef : shape->extraDataRefs) {
+			auto skinAttach = hdr.GetBlock<SkinAttach>(extraDataRef);
+			if (skinAttach) {
+				for (auto& bone : skinAttach->bones)
+					outList.push_back(bone.get());
+				break;
+			}
+		}
 	}
 
 	return static_cast<uint32_t>(outList.size());


### PR DESCRIPTION
## Summary
- **BSGeometry missing virtual overrides:** `BSGeometry` had `skinInstanceRef`, `shaderPropertyRef`, and `alphaPropertyRef` members and read them in `Sync()`, but never overrode the virtual accessors from `NiShape`. This caused `SkinInstanceRef()`, `IsSkinned()`, `HasShaderProperty()`, etc. to return null/false for all Starfield BSGeometry shapes — breaking skinning, bone loading, and shader/alpha property access.
- **SkinAttach bone name fallback:** `GetShapeBoneList` now falls back to `SkinAttach` extra data when `boneRefs` yield no bone NiNodes. Starfield NIFs store bone names as strings in `SkinAttach` instead of NiNode block references (all boneRefs are `0xFFFFFFFF`).

## Context
These two changes are required for Starfield mesh loading in Outfit Studio. Without the virtual overrides, no code path using the `NiShape` interface (skinning, shaders, alpha) works on BSGeometry shapes. Without the SkinAttach fallback, bone lists are empty for SF meshes.

## Test plan
- [x] Load SF body NIF (`naked_f.nif`) — 38 bones loaded via SkinAttach
- [x] Load SF outfit NIFs (swimsuit, Ajun torso, redeemed armor) — all shapes load bones correctly
- [x] `IsSkinned()` returns true for skinned BSGeometry shapes
- [x] `SkinInstanceRef()` returns valid ref for BSGeometry with BSSkinInstance
- [x] FO4/SSE NIFs continue to work unchanged (NiGeometry path unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)