### PR TITLE
Add BSGeometry bone weight loading from mesh data

### DIFF
--- a/src/NifFile.cpp
+++ b/src/NifFile.cpp
@@ -2568,14 +2568,15 @@ uint32_t NifFile::GetShapeBoneWeights(NiShape* shape,
 			// outWeights is keyed by uint16_t, so vertex indices are capped at
 			// 0xFFFF; iterate with a wide index to avoid overflowing the loop
 			// counter on meshes with more than 65535 vertices.
-			size_t vertCount = geomData->skinWeights.size();
-			if (vertCount > 0x10000)
-				vertCount = 0x10000;
+			constexpr size_t maxVerts = static_cast<size_t>(std::numeric_limits<uint16_t>::max()) + 1;
+			constexpr float maxWeightValue = static_cast<float>(std::numeric_limits<uint16_t>::max());
+
+			size_t vertCount = std::min(geomData->skinWeights.size(), maxVerts);
 			outWeights.reserve(vertCount);
 			for (size_t vid = 0; vid < vertCount; vid++) {
 				for (auto& bw : geomData->skinWeights[vid]) {
 					if (bw.boneIndex == boneIndex && bw.weight != 0) {
-						outWeights.emplace(static_cast<uint16_t>(vid), bw.weight / 65535.0f);
+						outWeights.emplace(static_cast<uint16_t>(vid), bw.weight / maxWeightValue);
 					}
 				}
 			}

--- a/src/NifFile.cpp
+++ b/src/NifFile.cpp
@@ -2565,13 +2565,13 @@ uint32_t NifFile::GetShapeBoneWeights(NiShape* shape,
 	if (bsGeom) {
 		auto* geomData = dynamic_cast<BSGeometryMeshData*>(bsGeom->GetGeomData());
 		if (geomData && !geomData->skinWeights.empty()) {
-			outWeights.reserve(geomData->skinWeights.size());
 			// outWeights is keyed by uint16_t, so vertex indices are capped at
 			// 0xFFFF; iterate with a wide index to avoid overflowing the loop
 			// counter on meshes with more than 65535 vertices.
 			size_t vertCount = geomData->skinWeights.size();
 			if (vertCount > 0x10000)
 				vertCount = 0x10000;
+			outWeights.reserve(vertCount);
 			for (size_t vid = 0; vid < vertCount; vid++) {
 				for (auto& bw : geomData->skinWeights[vid]) {
 					if (bw.boneIndex == boneIndex && bw.weight != 0) {

--- a/src/NifFile.cpp
+++ b/src/NifFile.cpp
@@ -2561,6 +2561,22 @@ uint32_t NifFile::GetShapeBoneWeights(NiShape* shape,
 		return static_cast<uint32_t>(outWeights.size());
 	}
 
+	auto bsGeom = dynamic_cast<BSGeometry*>(shape);
+	if (bsGeom) {
+		auto* geomData = dynamic_cast<BSGeometryMeshData*>(bsGeom->GetGeomData());
+		if (geomData && !geomData->skinWeights.empty()) {
+			outWeights.reserve(geomData->skinWeights.size());
+			for (uint16_t vid = 0; vid < geomData->skinWeights.size(); vid++) {
+				for (auto& bw : geomData->skinWeights[vid]) {
+					if (bw.boneIndex == boneIndex && bw.weight != 0) {
+						outWeights.emplace(vid, bw.weight / 65535.0f);
+					}
+				}
+			}
+			return static_cast<uint32_t>(outWeights.size());
+		}
+	}
+
 	auto skinInst = hdr.GetBlock<NiSkinInstance>(shape->SkinInstanceRef());
 	if (!skinInst)
 		return 0;

--- a/src/NifFile.cpp
+++ b/src/NifFile.cpp
@@ -2566,10 +2566,16 @@ uint32_t NifFile::GetShapeBoneWeights(NiShape* shape,
 		auto* geomData = dynamic_cast<BSGeometryMeshData*>(bsGeom->GetGeomData());
 		if (geomData && !geomData->skinWeights.empty()) {
 			outWeights.reserve(geomData->skinWeights.size());
-			for (uint16_t vid = 0; vid < geomData->skinWeights.size(); vid++) {
+			// outWeights is keyed by uint16_t, so vertex indices are capped at
+			// 0xFFFF; iterate with a wide index to avoid overflowing the loop
+			// counter on meshes with more than 65535 vertices.
+			size_t vertCount = geomData->skinWeights.size();
+			if (vertCount > 0x10000)
+				vertCount = 0x10000;
+			for (size_t vid = 0; vid < vertCount; vid++) {
 				for (auto& bw : geomData->skinWeights[vid]) {
 					if (bw.boneIndex == boneIndex && bw.weight != 0) {
-						outWeights.emplace(vid, bw.weight / 65535.0f);
+						outWeights.emplace(static_cast<uint16_t>(vid), bw.weight / 65535.0f);
 					}
 				}
 			}

--- a/tests/TestNifFile.cpp
+++ b/tests/TestNifFile.cpp
@@ -361,7 +361,7 @@ TEST_CASE("Load and save file (SF)", "[NifFile]") {
 
 TEST_CASE("BSGeometry bone weights are normalized (SF)", "[NifFile]") {
 	constexpr auto fileName = "TestNifFile_SF";
-	const auto [fileInput, fileOutput, fileExpected] = GetFileTuple(fileName, nifSuffix);
+	const auto fileInput = std::get<0>(GetFileTuple(fileName, nifSuffix));
 
 	NifFile nif;
 	REQUIRE(nif.Load(fileInput) == 0);
@@ -376,11 +376,14 @@ TEST_CASE("BSGeometry bone weights are normalized (SF)", "[NifFile]") {
 		REQUIRE(bsGeom != nullptr);
 
 		auto meshPaths = nif.GetExternalGeometryPathRefs(s);
+		REQUIRE(!meshPaths.empty());
+
 		uint8_t meshIndex = 0;
 		for (auto meshPath : meshPaths) {
 			std::string meshPathStr = meshPath.get();
-			const auto [meshFileInput, meshFileOutput, meshFileExpected]
-				= GetFileTuple(meshPathStr.c_str(), meshSuffix);
+			REQUIRE(!meshPathStr.empty());
+
+			const auto meshFileInput = std::get<0>(GetFileTuple(meshPathStr.c_str(), meshSuffix));
 			const std::filesystem::path meshInputPath = std::filesystem::u8path(meshFileInput);
 			auto meshStream = GetBinaryInputFileStream(meshInputPath);
 			REQUIRE(meshStream);

--- a/tests/TestNifFile.cpp
+++ b/tests/TestNifFile.cpp
@@ -359,6 +359,57 @@ TEST_CASE("Load and save file (SF)", "[NifFile]") {
 	REQUIRE(CompareBinaryFiles(fileOutput, fileExpected));
 }
 
+TEST_CASE("BSGeometry bone weights are normalized (SF)", "[NifFile]") {
+	constexpr auto fileName = "TestNifFile_SF";
+	const auto [fileInput, fileOutput, fileExpected] = GetFileTuple(fileName, nifSuffix);
+
+	NifFile nif;
+	REQUIRE(nif.Load(fileInput) == 0);
+
+	auto shapes = nif.GetShapes();
+	REQUIRE(!shapes.empty());
+
+	size_t weightedVertices = 0;
+
+	for (auto& s : shapes) {
+		auto* bsGeom = dynamic_cast<BSGeometry*>(s);
+		REQUIRE(bsGeom != nullptr);
+
+		auto meshPaths = nif.GetExternalGeometryPathRefs(s);
+		uint8_t meshIndex = 0;
+		for (auto meshPath : meshPaths) {
+			std::string meshPathStr = meshPath.get();
+			const auto [meshFileInput, meshFileOutput, meshFileExpected]
+				= GetFileTuple(meshPathStr.c_str(), meshSuffix);
+			const std::filesystem::path meshInputPath = std::filesystem::u8path(meshFileInput);
+			auto meshStream = GetBinaryInputFileStream(meshInputPath);
+			REQUIRE(meshStream);
+			REQUIRE(nif.LoadExternalShapeData(s, *meshStream, meshIndex));
+			meshStream.reset();
+			meshIndex++;
+		}
+
+		std::vector<std::string> bones;
+		nif.GetShapeBoneList(s, bones);
+
+		for (uint32_t boneIndex = 0; boneIndex < bones.size(); boneIndex++) {
+			std::unordered_map<uint16_t, float> weights;
+			nif.GetShapeBoneWeights(s, boneIndex, weights);
+
+			for (const auto& [vid, weight] : weights) {
+				REQUIRE(weight >= 0.0f);
+				REQUIRE(weight <= 1.0f);
+			}
+
+			weightedVertices += weights.size();
+		}
+	}
+
+	// The Starfield mesh fixture is skinned, so the BSGeometry path must
+	// actually return per-vertex weights (regression for the new code path).
+	REQUIRE(weightedVertices > 0);
+}
+
 TEST_CASE("Load external and save as internal mesh data (SF)", "[NifFile]") {
 	constexpr auto fileName = "TestNifFile_ToInternalMesh_SF";
 	const auto [fileInput, fileOutput, fileExpected] = GetFileTuple(fileName, nifSuffix);


### PR DESCRIPTION
## Summary
- Add a `BSGeometry` case to `GetShapeBoneWeights` that reads per-vertex bone weights from `BSGeometryMeshData::skinWeights` (packed `uint16` values where 65535 = 1.0)
- Fixes Starfield mesh vertices appearing unweighted in Outfit Studio

## Context
Follow-up to PR #60 (merged). This commit was on the same branch but not included in that PR.

🤖 Generated with the help of [Claude Code](https://claude.com/claude-code)
@