### PR TITLE
Starfield BSGeometry: generate/regenerate mesh-shader meshlets + support per-vertex weight editing

### DIFF
--- a/include/Geometry.hpp
+++ b/include/Geometry.hpp
@@ -606,6 +606,10 @@ public:
 	std::vector<CullData> cullDataList;
 
 	void Sync(NiStreamReversible& stream);
+
+	bool HasMeshlets() const { return !meshletList.empty(); }
+
+	void GenerateMeshlets(uint32_t maxVerts = 96, uint32_t maxPrims = 128);
 };
 
 struct BSGeometryMesh {
@@ -667,6 +671,32 @@ public:
 	const NiBlockRef<NiAlphaProperty>* AlphaPropertyRef() const override { return &alphaPropertyRef; }
 
 	uint8_t MeshCount() { return (uint8_t) meshes.size();	}
+
+	BSGeometryMesh* AddMesh() {
+		meshes.emplace_back();
+		selectedMesh = static_cast<uint8_t>(meshes.size() - 1);
+		return &meshes.back();
+	}
+
+	bool HasMeshlets() const {
+		for (auto& mesh : meshes) {
+			if(mesh.meshData.HasMeshlets()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	// Generate Starfield mesh-shader meshlets + cull data for every mesh slot that has triangle data. 
+	void GenerateMeshlets(uint32_t maxVerts = 96, uint32_t maxPrims = 128, bool onlyIfMissing = true) {
+		for (auto& mesh : meshes) {
+			if (onlyIfMissing && mesh.meshData.HasMeshlets())
+				continue;
+			if (mesh.meshData.tris.empty())
+				continue;
+			mesh.meshData.GenerateMeshlets(maxVerts, maxPrims);
+		}
+	}
 
 	// Flag 0x200 (512) on BSGeometry controls whether mesh data is embedded inline
 	// in the NIF (internal) or stored as separate .mesh files (external).

--- a/include/Geometry.hpp
+++ b/include/Geometry.hpp
@@ -609,7 +609,7 @@ public:
 
 	bool HasMeshlets() const { return !meshletList.empty(); }
 
-	void GenerateMeshlets(uint32_t maxVerts = 96, uint32_t maxPrims = 128);
+	void GenerateMeshlets(uint32_t maxVerts = 128, uint32_t maxPrims = 128);
 };
 
 struct BSGeometryMesh {
@@ -688,7 +688,7 @@ public:
 	}
 
 	// Generate Starfield mesh-shader meshlets + cull data for every mesh slot that has triangle data. 
-	void GenerateMeshlets(uint32_t maxVerts = 96, uint32_t maxPrims = 128, bool onlyIfMissing = true) {
+	void GenerateMeshlets(uint32_t maxVerts = 128, uint32_t maxPrims = 128, bool onlyIfMissing = true) {
 		for (auto& mesh : meshes) {
 			if (onlyIfMissing && mesh.meshData.HasMeshlets())
 				continue;

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -12,6 +12,7 @@ See the included GPLv3 LICENSE file
 #include "NifUtil.hpp"
 
 #include <array>
+#include <cfloat>
 #include <cmath>
 
 using namespace nifly;

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -1751,6 +1751,95 @@ void BSGeometryMeshData::Sync(NiStreamReversible& stream) {
 	}
 }
 
+void BSGeometryMeshData::GenerateMeshlets(uint32_t maxVerts, uint32_t maxPrims) {
+	meshletList.clear();
+	cullDataList.clear();
+	nMeshlets = 0;
+	nCullData = 0;
+
+	if (tris.empty() || vertices.empty()) {
+		return;
+	}
+
+	// A single triangle needs three distinct vertex slots; never go below that.
+	if (maxVerts < 3)
+		maxVerts = 3;
+	if (maxPrims < 1)
+		maxPrims = 1;
+
+	uint32_t startTri = 0;             // first triangle of the meshlet being built
+	uint32_t vertOffsetAccum = 0;      // running sum of emitted vertCounts (= vertOffset)
+	std::unordered_set<uint16_t> cur;  // distinct vertices in the meshlet being built
+
+	auto flush = [&](uint32_t endTri) {
+		if (endTri <= startTri)
+			return;
+
+		Meshlet m;
+		m.vertCount = static_cast<uint32_t>(cur.size());
+		m.vertOffset = vertOffsetAccum;
+		m.primCount = endTri - startTri;
+		m.primOffset = startTri;   // primOffset is in TRIANGLE units (matches vanilla SF meshlets)
+		meshletList.push_back(m);
+		vertOffsetAccum += m.vertCount;
+
+		// Per-meshlet AABB over the meshlet's vertices. Stored in metric units (NIF units divided by havokScale), matching how the game decodes positions for culling.
+		Vector3 mn(FLT_MAX, FLT_MAX, FLT_MAX);
+		Vector3 mx(-FLT_MAX, -FLT_MAX, -FLT_MAX);
+		for (uint16_t vi : cur) {
+			const Vector3& p = vertices[vi];
+			mn.x = std::min(mn.x, p.x);
+			mn.y = std::min(mn.y, p.y);
+			mn.z = std::min(mn.z, p.z);
+			mx.x = std::max(mx.x, p.x);
+			mx.y = std::max(mx.y, p.y);
+			mx.z = std::max(mx.z, p.z);
+		}
+
+		CullData cd;
+		cd.center = Vector3((mn.x + mx.x) * 0.5f, (mn.y + mx.y) * 0.5f, (mn.z + mx.z) * 0.5f) / havokScale;
+		cd.expand = Vector3((mx.x - mn.x) * 0.5f, (mx.y - mn.y) * 0.5f, (mx.z - mn.z) * 0.5f) / havokScale;
+		cullDataList.push_back(cd);
+
+		startTri = endTri;
+		cur.clear();
+	};
+
+	for (uint32_t t = 0; t < static_cast<uint32_t>(tris.size()); t++) {
+		const Triangle& tri = tris[t];
+		const uint16_t tv[3] = {tri.p1, tri.p2, tri.p3};
+
+		// Count how many distinct vertices this triangle would add to the current meshlet, ignoring vertices already present and degenerate repeats within the triangle.
+		uint32_t add = 0;
+		for (int a = 0; a < 3; a++) {
+			if (cur.count(tv[a]))
+				continue;
+			bool seenEarlier = false;
+			for (int b = 0; b < a; b++) {
+				if (tv[b] == tv[a]) {
+					seenEarlier = true;
+					break;
+				}
+			}
+			if (!seenEarlier)
+				add++;
+		}
+
+		uint32_t curPrims = t - startTri;
+		if (curPrims > 0 && (cur.size() + add > maxVerts || curPrims + 1 > maxPrims))
+			flush(t);
+
+		cur.insert(tri.p1);
+		cur.insert(tri.p2);
+		cur.insert(tri.p3);
+	}
+	flush(static_cast<uint32_t>(tris.size()));
+
+	nMeshlets = static_cast<uint32_t>(meshletList.size());
+	nCullData = static_cast<uint32_t>(cullDataList.size());
+	version = 2;
+}
+
 void BSGeometryMesh::Sync(NiStreamReversible& stream) {
 	stream.Sync(triSize);
 	stream.Sync(numVerts);
@@ -1834,7 +1923,21 @@ bool BSGeometry::GetTriangles(std::vector<Triangle>& tris) const {
 
 void BSGeometry::SetTriangles(const std::vector<Triangle>& tris) {
 	if (meshes.size() > selectedMesh) {
-		meshes[selectedMesh].meshData.tris = tris;
+		auto& meshData = meshes[selectedMesh].meshData;
+
+		// Detect whether the triangle topology actually changes.
+		bool changed = meshData.tris.size() != tris.size();
+		for (size_t i = 0; !changed && i < tris.size(); ++i) {
+			changed = meshData.tris[i].p1 != tris[i].p1 || meshData.tris[i].p2 != tris[i].p2 || meshData.tris[i].p3 != tris[i].p3;
+		}
+
+		meshData.tris = tris;
+
+		//If triangles changed, we want to drop the meshlets so export re-generates them. (only want to strip on invalidation, not if no changes occured)
+		if (changed) {
+			meshData.meshletList.clear();
+			meshData.cullDataList.clear();
+		}
 	}
 }
 

--- a/src/NifFile.cpp
+++ b/src/NifFile.cpp
@@ -2882,6 +2882,36 @@ void NifFile::SetShapeVertWeights(const std::string& shapeName,
 	if (!shape)
 		return;
 
+
+	// For starfield BSGeometry, per-vertex weights live in BSGeometryMeshData::skinWeights as nWeightsPerVert pairs of {u16 boneIndex, u16 quantized weight}
+	// boneids index into shapes BSSkin::Instance boneRefs
+	if(auto* bsGeom = dynamic_cast<BSGeometry*>(shape)) {
+		auto* geomData = dynamic_cast<BSGeometryMeshData*>(bsGeom->GetGeomData());
+		if(!geomData || vertIndex >= geomData->skinWeights.size()) {
+			return;
+		}
+
+		uint32_t wpv = geomData->nWeightsPerVert ? geomData->nWeightsPerVert : 4;
+
+		float sum = 0.0f;
+		for(auto weight : weights) {
+			sum += weight;
+		}
+		if(sum <= 0.f) {
+			sum = 1.f;
+		}
+
+		auto& vw = geomData->skinWeights[vertIndex];
+		vw.assign(wpv, BSGeometryMeshData::BoneWeight{});
+		uint32_t num = std::min<uint32_t>(static_cast<uint32_t>(weights.size()), wpv);
+		for(uint32_t i = 0; i< num; i++) {
+			vw[i].boneIndex = boneids[i];
+			vw[i].weight = static_cast<uint16_t>(std::lround((weights[i] / sum) * 65535.0f));
+		}
+		return;
+	} 
+
+
 	auto bsTriShape = dynamic_cast<BSTriShape*>(shape);
 	if (!bsTriShape)
 		return;
@@ -2910,6 +2940,20 @@ void NifFile::ClearShapeVertWeights(const std::string& shapeName) const {
 	auto shape = FindBlockByName<NiShape>(shapeName);
 	if (!shape)
 		return;
+
+
+	// For Starfield BSGeometry: reset skinWeights to one zeroed nWeightsPerVert-slot entry per vertex, SetShapeVertWeights will fill them and the .mesh writer writes good weights
+	if (auto* bsGeom = dynamic_cast<BSGeometry*>(shape)) {
+		auto* geomData = dynamic_cast<BSGeometryMeshData*>(bsGeom->GetGeomData());
+		if (!geomData) {
+			return;
+		}
+		if (geomData->nWeightsPerVert == 0) {
+			geomData->nWeightsPerVert = 4;
+		}
+		geomData->skinWeights.assign(geomData->vertices.size(), std::vector<BSGeometryMeshData::BoneWeight>(geomData->nWeightsPerVert));
+		return;
+	}
 
 	auto bsTriShape = dynamic_cast<BSTriShape*>(shape);
 	if (!bsTriShape)


### PR DESCRIPTION
Editing a Starfield `BSGeometry` mesh (e.g. splitting/deleting verts) and re-exporting currently renders exploded or invisible in-game.


- (re)Generate meshlets when no meshlets/cull data (gets cleared when triangle data changed so will regenerate)

- `SetShapeVertWeights`/`ClearShapeVertWeights`: handle `BSGeometry` so SF per-vertex skin weights rewritten after edit
