### PR TITLE
Starfield: support vertex deletion for Starfield BSGeometry shapes

### DIFF
--- a/include/Geometry.hpp
+++ b/include/Geometry.hpp
@@ -607,6 +607,8 @@ public:
 
 	void Sync(NiStreamReversible& stream);
 
+	void notifyVerticesDelete(const std::vector<uint16_t>& vertIndices) override;
+
 	bool HasMeshlets() const { return !meshletList.empty(); }
 
 	void GenerateMeshlets(uint32_t maxVerts = 128, uint32_t maxPrims = 128);
@@ -615,7 +617,7 @@ public:
 struct BSGeometryMesh {
 	uint32_t triSize = 0;
 	uint32_t numVerts = 0;
-	uint32_t flags = 0;		// Often 64
+	uint32_t flags = 0; // Often 64
 
 	// When internalGeom is false (default), meshName holds the external .mesh path
 	// (41 hex chars from sha1, or a human-readable name). When true, mesh data is
@@ -650,7 +652,7 @@ public:
 	void Sync(NiStreamReversible& stream);
 	void GetChildRefs(std::set<NiRef*>& refs) override;
 	void GetChildIndices(std::vector<uint32_t>& indices) override;
-		
+
 	NiGeometryData* GetGeomData() const override;
 
 	bool GetTriangles(std::vector<Triangle>& tris) const override;
@@ -670,7 +672,7 @@ public:
 	NiBlockRef<NiAlphaProperty>* AlphaPropertyRef() override { return &alphaPropertyRef; }
 	const NiBlockRef<NiAlphaProperty>* AlphaPropertyRef() const override { return &alphaPropertyRef; }
 
-	uint8_t MeshCount() { return (uint8_t) meshes.size();	}
+	uint8_t MeshCount() { return (uint8_t) meshes.size(); }
 
 	BSGeometryMesh* AddMesh() {
 		meshes.emplace_back();
@@ -680,14 +682,14 @@ public:
 
 	bool HasMeshlets() const {
 		for (auto& mesh : meshes) {
-			if(mesh.meshData.HasMeshlets()) {
+			if (mesh.meshData.HasMeshlets()) {
 				return true;
 			}
 		}
 		return false;
 	}
 
-	// Generate Starfield mesh-shader meshlets + cull data for every mesh slot that has triangle data. 
+	// Generate Starfield mesh-shader meshlets + cull data for every mesh slot that has triangle data.
 	void GenerateMeshlets(uint32_t maxVerts = 128, uint32_t maxPrims = 128, bool onlyIfMissing = true) {
 		for (auto& mesh : meshes) {
 			if (onlyIfMissing && mesh.meshData.HasMeshlets())

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -189,7 +189,7 @@ uint32_t NiGeometryData::GetNumTriangles() const {
 bool NiGeometryData::GetTriangles(std::vector<Triangle>&) const {
 	return false;
 }
-void NiGeometryData::SetTriangles(const std::vector<Triangle>&){};
+void NiGeometryData::SetTriangles(const std::vector<Triangle>&) {};
 
 void NiGeometryData::UpdateBounds() {
 	bounds = BoundingSphere(vertices);
@@ -343,7 +343,7 @@ bool NiShape::HasVertexColors() const {
 	return false;
 };
 
-void NiShape::SetSkinned(const bool){};
+void NiShape::SetSkinned(const bool) {};
 bool NiShape::IsSkinned() const {
 	return false;
 };
@@ -1752,6 +1752,54 @@ void BSGeometryMeshData::Sync(NiStreamReversible& stream) {
 	}
 }
 
+void BSGeometryMeshData::notifyVerticesDelete(const std::vector<uint16_t>& vertIndices) {
+	if (vertIndices.empty()) {
+		return;
+	}
+
+	std::vector<int> indexCollapse = GenerateIndexCollapseMap(vertIndices, vertices.size());
+
+	// Base handles vertices, normals, tangents and uvSets
+	NiGeometryData::notifyVerticesDelete(vertIndices);
+	nVertices = static_cast<uint32_t>(vertices.size());
+	nNormals = static_cast<uint32_t>(normals.size());
+	nTangents = static_cast<uint32_t>(tangents.size());
+	nUV1 = uvSets.size() > 0 ? static_cast<uint32_t>(uvSets[0].size()) : 0;
+	nUV2 = uvSets.size() > 1 ? static_cast<uint32_t>(uvSets[1].size()) : 0;
+
+	//Erase Starfield specific per-vertex arrays (vColors, tangentWs, skinWeights)
+	EraseVectorIndices(vColors, vertIndices);
+	nColors = static_cast<uint32_t>(vColors.size());
+
+	EraseVectorIndices(tangentWs, vertIndices);
+
+	EraseVectorIndices(skinWeights, vertIndices);
+	nTotalWeights = 0;
+	for (auto& vw : skinWeights) {
+		nTotalWeights += static_cast<uint32_t>(vw.size());
+	}
+
+	// Remap the main triangle list with the index collapse map
+	ApplyMapToTriangles(tris, indexCollapse);
+	nTriIndices = static_cast<uint32_t>(tris.size()) * 3;
+
+	//Also need to remap all lod triangle lists
+	for (auto& lod : lods) {
+		ApplyMapToTriangles(lod, indexCollapse);
+	}
+
+	// Need to rebuild Meshlets and cull data (if had any)
+	bool hadMeshlets = !meshletList.empty();
+	meshletList.clear();
+	cullDataList.clear();
+	nMeshlets = 0;
+	nCullData = 0;
+
+	if (hadMeshlets) {
+		GenerateMeshlets();
+	}
+}
+
 void BSGeometryMeshData::GenerateMeshlets(uint32_t maxVerts, uint32_t maxPrims) {
 	meshletList.clear();
 	cullDataList.clear();
@@ -1768,9 +1816,9 @@ void BSGeometryMeshData::GenerateMeshlets(uint32_t maxVerts, uint32_t maxPrims) 
 	if (maxPrims < 1)
 		maxPrims = 1;
 
-	uint32_t startTri = 0;             // first triangle of the meshlet being built
-	uint32_t vertOffsetAccum = 0;      // running sum of emitted vertCounts (= vertOffset)
-	std::unordered_set<uint16_t> cur;  // distinct vertices in the meshlet being built
+	uint32_t startTri = 0;			  // first triangle of the meshlet being built
+	uint32_t vertOffsetAccum = 0;	  // running sum of emitted vertCounts (= vertOffset)
+	std::unordered_set<uint16_t> cur; // distinct vertices in the meshlet being built
 
 	auto flush = [&](uint32_t endTri) {
 		if (endTri <= startTri)
@@ -1780,7 +1828,7 @@ void BSGeometryMeshData::GenerateMeshlets(uint32_t maxVerts, uint32_t maxPrims) 
 		m.vertCount = static_cast<uint32_t>(cur.size());
 		m.vertOffset = vertOffsetAccum;
 		m.primCount = endTri - startTri;
-		m.primOffset = startTri;   // primOffset is in TRIANGLE units (matches vanilla SF meshlets)
+		m.primOffset = startTri; // primOffset is in TRIANGLE units (matches vanilla SF meshlets)
 		meshletList.push_back(m);
 		vertOffsetAccum += m.vertCount;
 
@@ -1906,7 +1954,7 @@ void BSGeometry::GetChildIndices(std::vector<uint32_t>& indices) {
 NiGeometryData* BSGeometry::GetGeomData() const {
 	if (meshes.size() > selectedMesh) {
 		// Breaking const correctness here to cast to the desired level of the class heirarchy.
-		//   Perhaps NiShape GetGeomData should return a const* or it shouldn't be a const function? 
+		//   Perhaps NiShape GetGeomData should return a const* or it shouldn't be a const function?
 		return dynamic_cast<NiGeometryData*>(const_cast<BSGeometryMeshData*>(&meshes[selectedMesh].meshData));
 	}
 	return nullptr;
@@ -1929,7 +1977,8 @@ void BSGeometry::SetTriangles(const std::vector<Triangle>& tris) {
 		// Detect whether the triangle topology actually changes.
 		bool changed = meshData.tris.size() != tris.size();
 		for (size_t i = 0; !changed && i < tris.size(); ++i) {
-			changed = meshData.tris[i].p1 != tris[i].p1 || meshData.tris[i].p2 != tris[i].p2 || meshData.tris[i].p3 != tris[i].p3;
+			changed = meshData.tris[i].p1 != tris[i].p1 || meshData.tris[i].p2 != tris[i].p2
+					  || meshData.tris[i].p3 != tris[i].p3;
 		}
 
 		meshData.tris = tris;

--- a/src/NifFile.cpp
+++ b/src/NifFile.cpp
@@ -4258,6 +4258,29 @@ bool NifFile::DeleteVertsForShape(NiShape* shape, const std::vector<uint16_t>& i
 		}
 	}
 
+	auto bsGeometry = dynamic_cast<BSGeometry*>(shape);
+	if (bsGeometry) {
+		// Only the currently selected mesh is affected. 
+		// Other mesh slots (LODs) have independent vertex buffers that these indices don't apply to, 
+		// so their geometry is left as-is and can diverge from the edited mesh.
+		auto meshData = dynamic_cast<BSGeometryMeshData*>(bsGeometry->GetGeomData());
+		if (!meshData) {
+			return false;
+		}
+
+		// Vertex indices are 16-bit; meshes beyond that limit can't be indexed safely,
+		// so the deletion is skipped entirely rather than applied partially.
+		if (meshData->vertices.size() > std::numeric_limits<uint16_t>::max()) {
+			return false;
+		}
+
+		meshData->notifyVerticesDelete(indices);
+		if (meshData->vertices.empty() || meshData->tris.empty()) {
+			// Deleted all verts or tris
+			allVertsDeleted = true;
+		}
+	}
+
 	auto skinInst = hdr.GetBlock<NiSkinInstance>(shape->SkinInstanceRef());
 	if (skinInst) {
 		auto skinData = hdr.GetBlock(skinInst->dataRef);

--- a/tests/TestNifFile.cpp
+++ b/tests/TestNifFile.cpp
@@ -22,6 +22,25 @@ std::tuple<std::string, std::string, std::string> GetFileTuple(const char* fileN
 	return std::make_tuple(fileInput, fileOutput, fileExpected);
 }
 
+// Loads every external .mesh file referenced by a BSGeometry shape into its mesh slots.
+static void LoadAllExternalMeshData(NifFile& nif, NiShape* shape) {
+	auto meshPaths = nif.GetExternalGeometryPathRefs(shape);
+	REQUIRE(!meshPaths.empty());
+
+	uint8_t meshIndex = 0;
+	for (auto meshPath : meshPaths) {
+		std::string meshPathStr = meshPath.get();
+		REQUIRE(!meshPathStr.empty());
+
+		const auto meshFileInput = std::get<0>(GetFileTuple(meshPathStr.c_str(), meshSuffix));
+		auto meshStream = GetBinaryInputFileStream(std::filesystem::u8path(meshFileInput));
+		REQUIRE(meshStream);
+		REQUIRE(nif.LoadExternalShapeData(shape, *meshStream, meshIndex));
+		meshStream.reset();
+		meshIndex++;
+	}
+}
+
 TEST_CASE("Load not existing file", "[NifFile]") {
 	constexpr auto fileName = "not_existing.nif";
 
@@ -373,22 +392,7 @@ TEST_CASE("BSGeometry bone weights are normalized (SF)", "[NifFile]") {
 		auto* bsGeom = dynamic_cast<BSGeometry*>(s);
 		REQUIRE(bsGeom != nullptr);
 
-		auto meshPaths = nif.GetExternalGeometryPathRefs(s);
-		REQUIRE(!meshPaths.empty());
-
-		uint8_t meshIndex = 0;
-		for (auto meshPath : meshPaths) {
-			std::string meshPathStr = meshPath.get();
-			REQUIRE(!meshPathStr.empty());
-
-			const auto meshFileInput = std::get<0>(GetFileTuple(meshPathStr.c_str(), meshSuffix));
-			const std::filesystem::path meshInputPath = std::filesystem::u8path(meshFileInput);
-			auto meshStream = GetBinaryInputFileStream(meshInputPath);
-			REQUIRE(meshStream);
-			REQUIRE(nif.LoadExternalShapeData(s, *meshStream, meshIndex));
-			meshStream.reset();
-			meshIndex++;
-		}
+		LoadAllExternalMeshData(nif, s);
 
 		std::vector<std::string> bones;
 		nif.GetShapeBoneList(s, bones);
@@ -411,6 +415,84 @@ TEST_CASE("BSGeometry bone weights are normalized (SF)", "[NifFile]") {
 	REQUIRE(weightedVertices > 0);
 }
 
+TEST_CASE("Delete vertices for shape (SF)", "[NifFile]") {
+	constexpr auto fileName = "TestNifFile_SF";
+	const auto fileInput = std::get<0>(GetFileTuple(fileName, nifSuffix));
+
+	NifFile nif;
+	REQUIRE(nif.Load(fileInput) == 0);
+
+	auto shapes = nif.GetShapes();
+	REQUIRE(!shapes.empty());
+
+	for (auto& s : shapes) {
+		auto* bsGeom = dynamic_cast<BSGeometry*>(s);
+		REQUIRE(bsGeom != nullptr);
+
+		LoadAllExternalMeshData(nif, s);
+
+		auto* meshData = dynamic_cast<BSGeometryMeshData*>(bsGeom->GetGeomData());
+		REQUIRE(meshData != nullptr);
+
+		const uint32_t vertCountBefore = meshData->nVertices;
+		REQUIRE(vertCountBefore > 4);
+
+		const bool hadMeshlets = meshData->HasMeshlets();
+		const bool hadWeights = !meshData->skinWeights.empty();
+		const bool hadColors = !meshData->vColors.empty();
+		const bool hadNormals = meshData->normals.size() == vertCountBefore;
+		const bool hadTangents = meshData->tangents.size() == vertCountBefore;
+
+		// Delete a few vertices spread across the mesh (sorted ascending)
+		const std::vector<uint16_t> delIndices = {0,
+												  static_cast<uint16_t>(vertCountBefore / 2),
+												  static_cast<uint16_t>(vertCountBefore - 1)};
+
+		// Not all vertices were deleted, so the shape must not be flagged for removal
+		REQUIRE(!nif.DeleteVertsForShape(s, delIndices));
+
+		const uint32_t vertCountAfter = vertCountBefore - static_cast<uint32_t>(delIndices.size());
+		REQUIRE(meshData->nVertices == vertCountAfter);
+		REQUIRE(meshData->vertices.size() == vertCountAfter);
+		REQUIRE(s->GetNumVertices() == vertCountAfter);
+
+		if (hadWeights)
+			REQUIRE(meshData->skinWeights.size() == vertCountAfter);
+
+		if (hadColors)
+			REQUIRE(meshData->vColors.size() == vertCountAfter);
+
+		if (hadNormals)
+			REQUIRE(meshData->normals.size() == vertCountAfter);
+
+		if (hadTangents) {
+			REQUIRE(meshData->tangents.size() == vertCountAfter);
+			REQUIRE(meshData->tangentWs.size() == vertCountAfter);
+		}
+
+		// All triangles (including LODs) must only reference remaining vertices
+		REQUIRE(!meshData->tris.empty());
+
+		for (const auto& t : meshData->tris) {
+			REQUIRE(t.p1 < vertCountAfter);
+			REQUIRE(t.p2 < vertCountAfter);
+			REQUIRE(t.p3 < vertCountAfter);
+		}
+
+		for (const auto& lod : meshData->lods) {
+			for (const auto& t : lod) {
+				REQUIRE(t.p1 < vertCountAfter);
+				REQUIRE(t.p2 < vertCountAfter);
+				REQUIRE(t.p3 < vertCountAfter);
+			}
+		}
+
+		// Meshlets and cull data were rebuilt if the mesh had them before
+		REQUIRE(meshData->HasMeshlets() == hadMeshlets);
+		REQUIRE(meshData->meshletList.size() == meshData->cullDataList.size());
+	}
+}
+
 TEST_CASE("Load external and save as internal mesh data (SF)", "[NifFile]") {
 	constexpr auto fileName = "TestNifFile_ToInternalMesh_SF";
 	const auto [fileInput, fileOutput, fileExpected] = GetFileTuple(fileName, nifSuffix);
@@ -423,23 +505,7 @@ TEST_CASE("Load external and save as internal mesh data (SF)", "[NifFile]") {
 	REQUIRE(!shapes.empty());
 
 	for (auto& s : shapes) {
-		auto meshPaths = nif.GetExternalGeometryPathRefs(s);
-		REQUIRE(!meshPaths.empty());
-
-		uint8_t meshIndex = 0;
-		for (auto meshPath : meshPaths) {
-			std::string meshPathStr = meshPath.get();
-			REQUIRE(!meshPathStr.empty());
-
-			const auto [meshFileInput, meshFileOutput, meshFileExpected] = GetFileTuple(meshPathStr.c_str(), meshSuffix);
-			const std::filesystem::path meshInputPath = std::filesystem::u8path(meshFileInput);
-			auto meshStream = GetBinaryInputFileStream(meshInputPath);
-			REQUIRE(meshStream);
-
-			REQUIRE(nif.LoadExternalShapeData(s, *meshStream, meshIndex));
-			meshStream.reset();
-			meshIndex++;
-		}
+		LoadAllExternalMeshData(nif, s);
 
 		// Switch from external to internal mesh data
 		auto bsgeo = dynamic_cast<nifly::BSGeometry*>(s);


### PR DESCRIPTION
Allows ZapSliders to work for ex.

add notifyVerticesDelete implementation for BSGeometry. Handles starfield specific per-vertex arrays (colors,tangents,skinweights)

also fix some formatting